### PR TITLE
Códigos atualizados conforme especificação v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Todas as opcoes do `wsdl` estao disponíveis via os mesmos comandos, e os metodo
 ### Calculo simples de prazo:
 
 ```javascript
-var frete = require('frete');
+const frete = require('frete');
 
 frete()
     .cepOrigem('13467460')
-    .servico(frete.codigos.sedex)
+    .servico(frete.servicos.sedex)
     .prazo('13466321', function (err, results) {
         console.log(err);
         console.log(results);
@@ -40,20 +40,20 @@ frete()
 
 ### Calculo simples de preco:
 ```javascript
-var frete = require('frete');
+const frete = require('frete');
 
 frete()
     .cepOrigem('13467460')
     .peso(1)
-    .formato(1)
+    .formato(frete.formatos.caixaPacote)
     .comprimento(16)
     .altura(2)
     .largura(11)
     .diametro(1)
-    .maoPropria('N')
+    .maoPropria(frete.maoPropria.nao)
     .valorDeclarado(50)
-    .avisoRecebimento('S')
-    .servico(frete.codigos.sedex)
+    .avisoRecebimento(frete.avisoRecebimento.sim)
+    .servico(frete.servicos.sedex)
     .preco('13466321', function (err, results) {
         console.log(err);
         console.log(results);
@@ -62,20 +62,20 @@ frete()
 
 ### Calculo simples de preco e prazo:
 ```javascript
-var frete = require('frete');
+const frete = require('frete');
 
 frete()
     .cepOrigem('13467460')
     .peso(1)
-    .formato(1)
+    .formato(frete.formatos.caixaPacote)
     .comprimento(16)
     .altura(2)
     .largura(11)
     .diametro(1)
-    .maoPropria('N')
+    .maoPropria(frete.maoPropria.nao)
     .valorDeclarado(50)
-    .avisoRecebimento('S')
-    .servico(frete.codigos.sedex)
+    .avisoRecebimento(frete.avisoRecebimento.sim)
+    .servico(frete.servicos.sedex)
     .precoPrazo('13466321', function (err, results) {
         console.log(err);
         console.log(results);
@@ -85,8 +85,8 @@ frete()
 ### Default options:
 ```javascript
 
-var frete = require('frete');
-frete.cepOrigem('13467460').servico([ frete.codigos.sedex, frete.codigos.pac ]);
+const frete = require('frete');
+frete.cepOrigem('13467460').servico([ frete.servicos.sedex, frete.servicos.pac ]);
 
 frete().prazo('13466321', function (err, results) {
     console.log(err);
@@ -103,21 +103,21 @@ frete().prazo('13466321', function (err, results) {
 ### Objeto as config / More usages
 
 ```javascript
-var frete = require('frete');
-frete.cepOrigem('13467460').servico([ frete.codigos.sedex, frete.codigos.pac ]);
+const frete = require('frete');
+frete.cepOrigem('13467460').servico([ frete.servicos.sedex, frete.servicos.pac ]);
 
 frete({
     cepDestino: '13466321',
     peso: 1,
-    formato: 1,
+    formato: frete.formatos.caixaPacote,
     comprimento: 16,
     altura: 2,
     largura: 11,
     diametro: 1,
-    maoPropria: 'N',
+    maoPropria: frete.maoPropria.nao,
     valorDeclarado: 50,
-    avisoRecebimento: 'S'
-}).preco(function(err, result) {
+    avisoRecebimento: frete.avisoRecebimento.sim
+}).prazo(function(err, result) {
     console.log(err);
     console.log(result);
 });

--- a/frete.js
+++ b/frete.js
@@ -23,10 +23,55 @@ function extend (target /*, objs... */) {
     return target;
 };
 
+function frete (opts) {
+    opts = opts || {};
+    V.objectOrEmpty(opts, 'options');
+
+    return new Frete(extend({}, defaultOptions, opts));
+};
+
+frete.formatos = {
+    caixaPacote: 1,
+    roloPrisma: 2,
+    envelope: 3
+};
+
+frete.servicos = {
+    sedex: '04014',
+    sedexCobrar: '04065',
+    pac: '04510',
+    pacCobrar: '04707',
+    sedex10: '40215',
+    sedex12: '40169',
+    sedexHoje: '40290',
+};
+
+frete.codigos = frete.servicos;
+
+frete.servicos.names = {
+    '04014': 'SEDEX à vista',
+    '04065': 'SEDEX à vista pagamento na entrega',
+    '04510': 'PAC à vista',
+    '04707': 'PAC à vista pagamento na entrega',
+    '40215': 'SEDEX 10 (à vista e a faturar)*',
+    '40169': 'SEDEX 12 (à vista e a faturar)*',
+    '40290': 'SEDEX Hoje Varejo*'
+};
+
+frete.maoPropria = {
+    sim: 'S',
+    nao: 'N'
+};
+
+frete.avisoRecebimento = {
+    sim: 'S',
+    nao: 'N'
+};
+
 const defaultOptions = {
     sCepOrigem: '',
-    sCdMaoPropria: 'N',
-    sCdAvisoRecebimento: 'N',
+    sCdMaoPropria: frete.maoPropria.nao,
+    sCdAvisoRecebimento: frete.avisoRecebimento.nao,
 
     sDsSenha: '',
     nCdEmpresa: '',
@@ -53,29 +98,6 @@ const allOptions = [
     'sDtCalculo',
     'strDataCalculo'
 ];
-
-function frete (opts) {
-    opts = opts || {};
-    V.objectOrEmpty(opts, 'options');
-
-    return new Frete(extend({}, defaultOptions, opts));
-};
-
-frete.codigos = {
-    sedex: 40010,
-    sedexCobrar: 40045,
-    sedex10: 40215,
-    sedexHoje: 40290,
-    pac: 41106
-};
-
-frete.codigos.names = {
-    40010: 'Sedex',
-    40045: 'Sedex a cobrar',
-    40215: 'Sedex 10',
-    40290: 'Sedex hoje',
-    41106: 'PAC'
-};
 
 allOptions.forEach(function (propertyName) {
     let setterName = getSetterName(propertyName);
@@ -284,7 +306,7 @@ function decorateServices (services) {
             let keyCamelCase = key[0].toLowerCase() + '' + key.substring(1);
             service[keyCamelCase] = value;
         }
-        service.name = frete.codigos.names[service.codigo];
+        service.name = frete.servicos.names[String(service.codigo).padStart(5, '0')];
     });
 
     return services;

--- a/frete.spec.js
+++ b/frete.spec.js
@@ -43,15 +43,15 @@ describe("Frete", function () {
         assert.deepEqual(defaultOptions, expected);
 
         frete.cepOrigem('13467460').servico([
-            frete.codigos.sedex,
-            frete.codigos.sedex10,
-            frete.codigos.pac
+            frete.servicos.sedex,
+            frete.servicos.sedex10,
+            frete.servicos.pac
         ]);
 
         assert.notDeepEqual(defaultOptions, expected);
 
         expected.sCepOrigem = '13467460';
-        expected.nCdServico = [ 40010, 40215, 41106 ];
+        expected.nCdServico = [ '04014', '40215', '04510' ];
 
         assert.deepEqual(defaultOptions, expected);
     });


### PR DESCRIPTION
As seguintes alterações foram realizadas:

- Códigos de serviços atualizados conforme documentação Versão 2.1 de 13/05/2019
- Criadas constantes para códigos de domínios:
  - `frete.servicos` (sedex, pac, etc)
  - `frete.formatos` (caixaPacote, envelope, etc)
  - `frete.maoPropria` (sim, nao)
  - `frete.avisoRecebimento` (sim, nao)
- Descrição do serviço na resposta atualizado conforme especificação

A documentação foi atualizada para refletir as alterações realizadas.